### PR TITLE
feat: 도메인 엔티티 모델 생성

### DIFF
--- a/daily_cs_api/compose.yml
+++ b/daily_cs_api/compose.yml
@@ -1,0 +1,10 @@
+services:
+  mysql:
+    image: 'mysql:latest'
+    environment:
+      - 'MYSQL_DATABASE=daily_cs_db'
+      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_ROOT_PASSWORD=rootsecret'
+      - 'MYSQL_USER=user'
+    ports:
+      - '3306:3306'

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/AbstractEntity.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/AbstractEntity.java
@@ -1,0 +1,42 @@
+package com.jjangsky.dcs.domain;
+
+import io.micrometer.common.lang.Nullable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.util.Objects;
+
+@MappedSuperclass
+@ToString(callSuper = true)
+public class AbstractEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter(onMethod_ = {@Nullable})
+    private Long id;
+
+    /**
+     * identity 전략을 사용하고 있는 경우 DB에 저장하기 전에는 id 값이 null로 저장되어 있는데
+     * 이 과정에서 비즈니스 로직을 처리하게 되면 오류를 접할 수 있어 null 체크를 해줘야 한다.
+     */
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        AbstractEntity that = (AbstractEntity) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/Member.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/Member.java
@@ -1,0 +1,55 @@
+package com.jjangsky.dcs.domain.member;
+
+import com.jjangsky.dcs.domain.AbstractEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.NaturalIdCache;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@DynamicUpdate
+@NaturalIdCache
+public class Member extends AbstractEntity {
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column
+    private String profileImageUrl;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(nullable = false)
+    private LocalDateTime registeredAt;
+
+    @Column
+    private LocalDateTime lastLoginAt;
+
+    @Column(nullable = false)
+    private final boolean isGitAgreed = false;
+
+    @Column
+    private LocalDateTime gitAgreedAt;
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/SocialType.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/SocialType.java
@@ -1,0 +1,8 @@
+package com.jjangsky.dcs.domain.member;
+
+public enum SocialType {
+    GOOGLE,
+    KAKAO,
+    GITHUB,
+    NONE
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/Status.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/member/Status.java
@@ -1,0 +1,5 @@
+package com.jjangsky.dcs.domain.member;
+
+public enum Status {
+    ACTIVE, INACTIVE, DELETED
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Level.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Level.java
@@ -1,0 +1,4 @@
+package com.jjangsky.dcs.domain.problem;
+
+public enum Level {
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Level.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Level.java
@@ -1,4 +1,17 @@
 package com.jjangsky.dcs.domain.problem;
 
+import lombok.Getter;
+
+@Getter
 public enum Level {
+    EASY("쉬움"),
+    NORMAL("보통"),
+    HARD("어려움");
+
+    private final String description;
+
+    Level(String description) {
+        this.description = description;
+    }
+
 }

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Problem.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Problem.java
@@ -1,0 +1,35 @@
+package com.jjangsky.dcs.domain.problem;
+
+import com.jjangsky.dcs.domain.AbstractEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@DynamicUpdate
+public class Problem extends AbstractEntity {
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Level level;
+
+    @Column(columnDefinition = "TEXT")
+    private String hint;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Tag.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/problem/Tag.java
@@ -1,0 +1,22 @@
+package com.jjangsky.dcs.domain.problem;
+
+import com.jjangsky.dcs.domain.AbstractEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Tag extends AbstractEntity {
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Tag(String name) {
+        this.name = name;
+    }
+}

--- a/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/submit/Submit.java
+++ b/daily_cs_api/src/main/java/com/jjangsky/dcs/domain/submit/Submit.java
@@ -1,0 +1,52 @@
+package com.jjangsky.dcs.domain.submit;
+
+
+import com.jjangsky.dcs.domain.AbstractEntity;
+import com.jjangsky.dcs.domain.member.Member;
+import com.jjangsky.dcs.domain.problem.Problem;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.NaturalIdCache;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@DynamicUpdate
+@NaturalIdCache
+public class Submit extends AbstractEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String answer;
+
+    @Column(nullable = false)
+    private LocalDateTime registeredAt;
+
+    @Column
+    private Integer score;
+
+    @Column(columnDefinition = "TEXT")
+    private String feedback;
+
+    @Column(nullable = false)
+    private final boolean isPublished = false;
+
+    @Column(nullable = false)
+    private final boolean isDeleted = false;
+
+    @Column
+    private LocalDateTime deletedAt;
+}

--- a/daily_cs_api/src/main/resources/application.properties
+++ b/daily_cs_api/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=daily_cs_api

--- a/daily_cs_api/src/main/resources/application.yml
+++ b/daily_cs_api/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/daily_cs_db?serverTimezone=Asia/Seoul
+    username: system
+    password: 3916
+    jpa:
+      open-in-view: false
+      hibernate:
+        ddl-auto: update
+      properties:
+        hibernate:
+          default_batch_fetch_size: 100
+          dialect: org.hibernate.dialect.MySQL8Dialect
+
+  application.name: splearn
+  jpa:
+    show-sql: true
+    hibernate:
+        ddl-auto: update


### PR DESCRIPTION
## Issues
* #9 

## Description

  1. 도메인 기본 구조 설계

  Daily CS 서비스의 핵심 도메인 모델을 JPA 엔티티로 구현했습니다.

  2. 구현된 도메인 모델

  AbstractEntity (Base Entity)

  - 모든 엔티티의 공통 필드를 관리하는 추상 클래스
  - @GeneratedValue(strategy = GenerationType.IDENTITY)로 ID 자동 생성
  - Hibernate Proxy를 고려한 equals/hashCode 구현
  - ID가 null일 경우를 대비한 안전한 비교 로직 구현

  Member (회원)

  - 회원 정보 관리 엔티티
  - 주요 필드:
    - email: 이메일 (필수)
    - nickname: 닉네임 (필수)
    - passwordHash: 비밀번호 해시 (필수)
    - profileImageUrl: 프로필 이미지 URL
    - socialType: 소셜 로그인 타입 (ENUM)
    - status: 회원 상태 (ENUM)
    - isGitAgreed: GitHub 연동 동의 여부
    - gitAgreedAt: GitHub 연동 동의 시간
  - @NaturalIdCache 적용으로 성능 최적화

  Problem (문제)

  - CS 문제 정보를 저장하는 엔티티
  - 주요 필드:
    - content: 문제 내용 (TEXT, 필수)
    - level: 난이도 (ENUM - EASY, MEDIUM, HARD)
    - hint: 힌트 (TEXT)
    - tag: 문제 카테고리 (Tag 엔티티와 ManyToOne 관계)
    - createdAt: 생성 시간
  - @DynamicUpdate 적용으로 변경된 필드만 업데이트

  Tag (문제 카테고리)

  - 문제 분류를 위한 태그 엔티티
  - 주요 필드:
    - name: 태그명 (자료구조, 알고리즘, 네트워크 등)
    - description: 태그 설명
    - displayOrder: 표시 순서

  Submit (제출 내역)

  - 회원의 문제 제출 내역 관리
  - 주요 필드:
    - member: 제출한 회원 (ManyToOne)
    - problem: 제출한 문제 (ManyToOne)
    - answer: 제출 답안 (TEXT, 필수)
    - score: 채점 점수
    - feedback: AI 피드백 (TEXT)
    - isPublished: 공개 여부
    - isDeleted: 삭제 여부 (Soft Delete)
    - deletedAt: 삭제 시간

  3. Enum 타입 정의

  - SocialType: 소셜 로그인 타입 (GOOGLE, GITHUB 등)
  - Status: 회원 상태 (ACTIVE, INACTIVE, SUSPENDED 등)
  - Level: 문제 난이도 (EASY, MEDIUM, HARD)

  4. MySQL 연동 설정

  - Docker Compose를 통한 MySQL 8.0 컨테이너 설정
  - application.yml에 JPA/Hibernate 설정 추가
    - spring.jpa.hibernate.ddl-auto: update
    - spring.jpa.show-sql: true
    - MySQL 8.0 dialect 설정

  5. 기술적 특징

  - Lombok 활용: 보일러플레이트 코드 최소화
  - JPA Best Practices 적용:
    - Lazy Loading 기본 적용
    - @DynamicUpdate로 성능 최적화
    - @NaturalIdCache로 캐싱 활용
  - Soft Delete 패턴: Submit 엔티티에 논리적 삭제 구현
  - 안전한 Entity 생성: protected 생성자로 무분별한 객체 생성 방지

  🎯 PR 체크리스트

  - 도메인 모델 설계 완료
  - JPA 엔티티 구현
  - MySQL 연동 설정
  - Enum 타입 정의
  - 코드 컨벤션 준수
